### PR TITLE
Fix "woff" extension (was typo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ This package requires a `map` of fonts that contains:
 - **source path** - an absolute path where to look for a font
 - **destination path** - an absolute path where to put that font
 
-**- `extensions: array`** default: `ttf, woof`
+**- `extensions: array`** default: `ttf, woff`
 
 It also depends on `extensions`. It tells the plugin which files we want to use as fonts.
 
 By default:
 - ttf
-- woof
+- woff
 
 **- `verbose: boolean`** default: `false`
 
-Displays informations about used fonts.
+Displays information about used fonts.
 
 It's important to keep `fonts.json` inside the **root directory** of your app.
 

--- a/plugin.js
+++ b/plugin.js
@@ -10,7 +10,7 @@ const defaultConfig = {
   verbose: false,
   extensions: [
     'ttf',
-    'woof'
+    'woff'
   ],
   map: {}
 };


### PR DESCRIPTION
It seems to me that `"woof"` file extension should actually have been `"woff"`?
https://www.w3.org/TR/WOFF/
https://en.wikipedia.org/wiki/Web_Open_Font_Format

In my case I often mistype it as "woof" indeed…